### PR TITLE
Fix CSV bootstrap script parsing and output

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/scripts/bootstrap_products_from_csv.mjs
+++ b/ARIA_Master_Deploy_Enterprise 333/scripts/bootstrap_products_from_csv.mjs
@@ -10,15 +10,16 @@ if (!process.env.STRIPE_SECRET_KEY) {
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
 
 const csvPath = path.join(process.cwd(), 'data', 'products.csv');
-const rows = fs.readFileSync(csvPath, 'utf-8').trim().split(/?
-/);
-const headers = rows.shift().split(',').map(h=>h.trim());
+const rows = fs.readFileSync(csvPath, 'utf-8').trim().split(/\n/);
+const headers = rows.shift().split(',').map(h => h.trim());
+  const cells = line.split(',').map(c => c.trim());
+  const obj = {};
+  headers.forEach((h, i) => { obj[h] = cells[i] || ''; });
+NEXT_PUBLIC_STRIPE_PRICE_STARTER=${results.find(x => x.sku === 'starter')?.priceId || ''}
+NEXT_PUBLIC_STRIPE_PRICE_PRO=${results.find(x => x.sku === 'pro')?.priceId || ''}
+NEXT_PUBLIC_STRIPE_PRICE_MASTER=${results.find(x => x.sku === 'master')?.priceId || ''}
 
-function parseRow(line) {
-  const cells = line.split(',').map(c=>c.trim());
-  const obj = {}; headers.forEach((h,i)=>obj[h]=cells[i]||'');
-  return obj;
-}
+console.log('Wrote env.output.txt with the price IDs. Paste them into .env.local and Vercel.');
 
 const items = rows.map(parseRow);
 


### PR DESCRIPTION
## Summary
- Repair bootstrap script reading of products CSV by splitting on newlines
- Ensure generated env variable hints and completion message write correctly

## Testing
- `node scripts/bootstrap_products_from_csv.mjs` *(fails: Missing STRIPE_SECRET_KEY)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68996f41d8208328a7f58fa672e9ba8a