### PR TITLE
test: add checkout route tests

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/__tests__/checkout-route.test.ts
+++ b/ARIA_Master_Deploy_Enterprise 333/__tests__/checkout-route.test.ts
@@ -1,0 +1,59 @@
+import Stripe from 'stripe';
+import type { NextRequest } from 'next/server';
+
+// Mock the Stripe SDK
+const createSessionMock = jest.fn().mockResolvedValue({ url: 'https://example.com/session' });
+
+jest.mock('stripe', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      checkout: { sessions: { create: createSessionMock } },
+    })),
+  };
+});
+
+describe('POST /api/checkout', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    createSessionMock.mockClear();
+    process.env.STRIPE_SECRET_KEY = 'sk_test';
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://example.com';
+    process.env.NEXT_PUBLIC_STRIPE_PRICE_BUMP = 'price_bump';
+  });
+
+  it('adds order bump line item when bump is true', async () => {
+    const { POST } = await import('@/app/api/checkout/route');
+    const { ORDER_BUMP_PRICE_ID } = await import('@/lib/products');
+
+    const body = { priceId: 'base_price', bump: true, tier: '' };
+    const req = { json: async () => body } as unknown as NextRequest;
+
+    await POST(req);
+
+    expect(createSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [
+          { price: 'base_price', quantity: 1 },
+          { price: ORDER_BUMP_PRICE_ID, quantity: 1 },
+        ],
+      }),
+    );
+  });
+
+  it('includes tier value in success_url', async () => {
+    const { POST } = await import('@/app/api/checkout/route');
+
+    const body = { priceId: 'base_price', bump: false, tier: 'gold' };
+    const req = { json: async () => body } as unknown as NextRequest;
+
+    await POST(req);
+
+    expect(createSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success_url: expect.stringContaining('tier=gold'),
+      }),
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add checkout route tests verifying order bump line item and success url tier

## Testing
- `npx jest __tests__/checkout-route.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_6899720202f083289490fcc60a6d4d58