### PR TITLE
Standardize tier identifiers on product slugs

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/README.md
+++ b/ARIA_Master_Deploy_Enterprise 333/README.md
@@ -57,6 +57,7 @@ Stripe Dashboard → Developers → Webhooks → Add endpoint:
 ---
 
 ### Notes
+- The `tier` query parameter uses product slugs (`starter-kit`, `professional-suite`, `master-collection`) for post-purchase logic
 - Upsell endpoint: `/api/upsell` uses `NEXT_PUBLIC_STRIPE_PRICE_UPGRADE_TO_PRO/MASTER`
 - Bump checkbox toggles a second line item in `/api/checkout`
 - Extend fulfillment logic in `/api/webhook` (email access, CRM tags, etc.)

--- a/ARIA_Master_Deploy_Enterprise 333/app/products/page.tsx
+++ b/ARIA_Master_Deploy_Enterprise 333/app/products/page.tsx
@@ -4,12 +4,12 @@ import { products } from '@/lib/products';
 
 export default function Products() {
   const [bumpChecked, setBumpChecked] = useState(true);
-  const handleCheckout = async (priceId?: string) => {
+  const handleCheckout = async (priceId?: string, tier?: string) => {
     if (!priceId) return;
     const res = await fetch('/api/checkout', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ priceId, bump: bumpChecked })
+      body: JSON.stringify({ priceId, bump: bumpChecked, tier })
     });
     const data = await res.json();
     if (data.url) window.location.href = data.url;
@@ -29,7 +29,7 @@ export default function Products() {
               <li>✔ Money-back guarantee</li>
             </ul>
             <div className="mt-4 font-semibold">${(p.price/100).toFixed(2)}</div>
-            <button className="btn-primary w-full mt-6" onClick={() => handleCheckout(p.stripePriceId)} disabled={!p.stripePriceId}>
+            <button className="btn-primary w-full mt-6" onClick={() => handleCheckout(p.stripePriceId, p.id)} disabled={!p.stripePriceId}>
               {p.stripePriceId ? 'Buy Now' : 'Set PRICE ID'}
             </button>
           </div>

--- a/ARIA_Master_Deploy_Enterprise 333/app/success/page.tsx
+++ b/ARIA_Master_Deploy_Enterprise 333/app/success/page.tsx
@@ -3,9 +3,9 @@ import { useSearchParams } from 'next/navigation';
 
 export default function Success() {
   const params = useSearchParams();
-  const tier = params.get('tier'); // 'starter' | 'pro' | 'master'
-  const nextOffer = tier === 'starter' ? { name: 'Upgrade to Professional', key: 'pro-upgrade' } :
-                    tier === 'pro' ? { name: 'Upgrade to Master', key: 'master-upgrade' } : null;
+  const tier = params.get('tier'); // 'starter-kit' | 'professional-suite' | 'master-collection'
+  const nextOffer = tier === 'starter-kit' ? { name: 'Upgrade to Professional', key: 'pro-upgrade' } :
+                    tier === 'professional-suite' ? { name: 'Upgrade to Master', key: 'master-upgrade' } : null;
 
   const accept = async () => {
     if (!nextOffer) return;

--- a/ARIA_Master_Deploy_Enterprise 333/data/products.csv
+++ b/ARIA_Master_Deploy_Enterprise 333/data/products.csv
@@ -1,5 +1,5 @@
 name,description,amount_cents,currency,sku
-ARIA Starter Kit,Complete framework + implementation guides for personal growth.,9700,usd,starter
-ARIA Professional Suite,Full professional package with advanced tools and training.,19700,usd,pro
-ARIA Master Collection,Ultimate system with exclusive templates, community, and consultation.,29700,usd,master
+ARIA Starter Kit,Complete framework + implementation guides for personal growth.,9700,usd,starter-kit
+ARIA Professional Suite,Full professional package with advanced tools and training.,19700,usd,professional-suite
+ARIA Master Collection,Ultimate system with exclusive templates, community, and consultation.,29700,usd,master-collection
 Fast-Start Worksheets (Order Bump),Actionable templates to accelerate results.,4700,usd,order-bump

--- a/ARIA_Master_Deploy_Enterprise 333/scripts/bootstrap_products_from_csv.mjs
+++ b/ARIA_Master_Deploy_Enterprise 333/scripts/bootstrap_products_from_csv.mjs
@@ -25,9 +25,9 @@ const items = rows.map(parseRow);
 const results = [];
 for (const item of items) {
   const product = await stripe.products.create({
-    name: item.name,
-    description: item.description
-  });
+NEXT_PUBLIC_STRIPE_PRICE_STARTER=${results.find(x=>x.sku==='starter-kit')?.priceId || ''}
+NEXT_PUBLIC_STRIPE_PRICE_PRO=${results.find(x=>x.sku==='professional-suite')?.priceId || ''}
+NEXT_PUBLIC_STRIPE_PRICE_MASTER=${results.find(x=>x.sku==='master-collection')?.priceId || ''}
   const price = await stripe.prices.create({
     product: product.id,
     currency: item.currency || 'usd',


### PR DESCRIPTION
## Summary
- Pass product slug as tier during checkout
- Use slug-based tiers in success page and docs
- Update CSV and Stripe bootstrap script to use product slugs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: ReferenceError: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_6899720a95bc83288def6868ea2fda4e