### PR TITLE
Validate checkout tier and handle unknown values

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/__tests__/checkout-route.test.ts
+++ b/ARIA_Master_Deploy_Enterprise 333/__tests__/checkout-route.test.ts
@@ -26,7 +26,7 @@ describe('POST /api/checkout', () => {
     const { POST } = await import('@/app/api/checkout/route');
     const { ORDER_BUMP_PRICE_ID } = await import('@/lib/products');
 
-    const body = { priceId: 'base_price', bump: true, tier: '' };
+    const body = { priceId: 'base_price', bump: true, tier: 'starter-kit' };
     const req = { json: async () => body } as unknown as NextRequest;
 
     await POST(req);
@@ -44,16 +44,29 @@ describe('POST /api/checkout', () => {
   it('includes tier value in success_url', async () => {
     const { POST } = await import('@/app/api/checkout/route');
 
-    const body = { priceId: 'base_price', bump: false, tier: 'gold' };
+    const body = { priceId: 'base_price', bump: false, tier: 'starter-kit' };
     const req = { json: async () => body } as unknown as NextRequest;
 
     await POST(req);
 
     expect(createSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        success_url: expect.stringContaining('tier=gold'),
+        success_url: expect.stringContaining('tier=starter-kit'),
       }),
     );
+  });
+
+  it('sanitizes unknown tier values', async () => {
+    const { POST } = await import('@/app/api/checkout/route');
+
+    const body = { priceId: 'base_price', bump: false, tier: 'gold' };
+    const req = { json: async () => body } as unknown as NextRequest;
+
+    await POST(req);
+
+    const successUrl = createSessionMock.mock.calls[0][0].success_url as string;
+    expect(successUrl).toContain('tier=');
+    expect(successUrl).not.toContain('tier=gold');
   });
 });
 

--- a/ARIA_Master_Deploy_Enterprise 333/app/api/checkout/route.ts
+++ b/ARIA_Master_Deploy_Enterprise 333/app/api/checkout/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
-import { ORDER_BUMP_PRICE_ID } from '@/lib/products';
+import { ORDER_BUMP_PRICE_ID, products } from '@/lib/products';
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
   const priceId: string = body.priceId;
   const bump: boolean = !!body.bump;
+  const tier: string = typeof body.tier === 'string' ? body.tier : '';
+  const safeTier = products.some(p => p.id === tier) ? tier : '';
 
   if (!process.env.STRIPE_SECRET_KEY) return NextResponse.json({ error: 'Missing STRIPE_SECRET_KEY' }, { status: 500 });
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
@@ -20,7 +22,7 @@ export async function POST(req: NextRequest) {
   const session = await stripe.checkout.sessions.create({
     mode: 'payment',
     line_items,
-    success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/success?tier=${encodeURIComponent(body.tier || '')}&session_id={CHECKOUT_SESSION_ID}`,
+    success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/success?tier=${encodeURIComponent(safeTier)}&session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${process.env.NEXT_PUBLIC_SITE_URL}/cancel`,
     allow_promotion_codes: true
   });


### PR DESCRIPTION
## Summary
- ensure checkout `tier` matches known products and sanitize unknown values
- test checkout route with valid and invalid tiers

## Testing
- `npx jest __tests__/checkout-route.test.ts --runInBand` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689981b970848328a6e8afc216c7ec75