### PR TITLE
Validate checkout tiers against product list

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/__tests__/checkout-route.test.ts
+++ b/ARIA_Master_Deploy_Enterprise 333/__tests__/checkout-route.test.ts
@@ -44,16 +44,28 @@ describe('POST /api/checkout', () => {
   it('includes tier value in success_url', async () => {
     const { POST } = await import('@/app/api/checkout/route');
 
-    const body = { priceId: 'base_price', bump: false, tier: 'gold' };
+    const body = { priceId: 'base_price', bump: false, tier: 'starter-kit' };
     const req = { json: async () => body } as unknown as NextRequest;
 
     await POST(req);
 
     expect(createSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        success_url: expect.stringContaining('tier=gold'),
+        success_url: expect.stringContaining('tier=starter-kit'),
       }),
     );
+  });
+
+  it('rejects unknown tier', async () => {
+    const { POST } = await import('@/app/api/checkout/route');
+
+    const body = { priceId: 'base_price', bump: false, tier: 'invalid-tier' };
+    const req = { json: async () => body } as unknown as NextRequest;
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    expect(createSessionMock).not.toHaveBeenCalled();
   });
 });
 

--- a/ARIA_Master_Deploy_Enterprise 333/app/api/checkout/route.ts
+++ b/ARIA_Master_Deploy_Enterprise 333/app/api/checkout/route.ts
@@ -1,11 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
-import { ORDER_BUMP_PRICE_ID } from '@/lib/products';
+import { ORDER_BUMP_PRICE_ID, products } from '@/lib/products';
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
   const priceId: string = body.priceId;
   const bump: boolean = !!body.bump;
+  const tier: string | undefined = body.tier;
+
+  if (tier && !products.find((p) => p.id === tier)) {
+    return NextResponse.json({ error: 'Invalid tier' }, { status: 400 });
+  }
 
   if (!process.env.STRIPE_SECRET_KEY) return NextResponse.json({ error: 'Missing STRIPE_SECRET_KEY' }, { status: 500 });
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
@@ -20,7 +25,7 @@ export async function POST(req: NextRequest) {
   const session = await stripe.checkout.sessions.create({
     mode: 'payment',
     line_items,
-    success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/success?tier=${encodeURIComponent(body.tier || '')}&session_id={CHECKOUT_SESSION_ID}`,
+    success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/success?tier=${encodeURIComponent(tier || '')}&session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${process.env.NEXT_PUBLIC_SITE_URL}/cancel`,
     allow_promotion_codes: true
   });


### PR DESCRIPTION
## Summary
- validate requested checkout tier against known products
- sanitize success URL with verified tier
- test success URL tier inclusion and rejection of invalid tiers

## Testing
- `npx jest` *(fails: 403 Forbidden – cannot download jest)*

------
https://chatgpt.com/codex/tasks/task_e_68998b0920848328b5810f0ace775d6a