### PR TITLE
test: add upsell route tests

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/__tests__/upsell-route.test.ts
+++ b/ARIA_Master_Deploy_Enterprise 333/__tests__/upsell-route.test.ts
@@ -1,0 +1,68 @@
+import Stripe from 'stripe';
+import type { NextRequest } from 'next/server';
+
+// Mock the Stripe SDK
+const createSessionMock = jest.fn().mockResolvedValue({ url: 'https://example.com/session' });
+
+jest.mock('stripe', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      checkout: { sessions: { create: createSessionMock } },
+    })),
+  };
+});
+
+describe('POST /api/upsell', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    createSessionMock.mockClear();
+    process.env.STRIPE_SECRET_KEY = 'sk_test';
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://example.com';
+    process.env.NEXT_PUBLIC_STRIPE_PRICE_UPGRADE_TO_PRO = 'price_pro';
+    process.env.NEXT_PUBLIC_STRIPE_PRICE_UPGRADE_TO_MASTER = 'price_master';
+  });
+
+  it('creates session for pro-upgrade offer', async () => {
+    const { POST } = await import('@/app/api/upsell/route');
+
+    const body = { offer: 'pro-upgrade' };
+    const req = { json: async () => body } as unknown as NextRequest;
+
+    await POST(req);
+
+    expect(createSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: 'price_pro', quantity: 1 }],
+      }),
+    );
+  });
+
+  it('creates session for master-upgrade offer', async () => {
+    const { POST } = await import('@/app/api/upsell/route');
+
+    const body = { offer: 'master-upgrade' };
+    const req = { json: async () => body } as unknown as NextRequest;
+
+    await POST(req);
+
+    expect(createSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: 'price_master', quantity: 1 }],
+      }),
+    );
+  });
+
+  it('returns 400 for invalid offer', async () => {
+    const { POST } = await import('@/app/api/upsell/route');
+
+    const body = { offer: 'invalid' };
+    const req = { json: async () => body } as unknown as NextRequest;
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    expect(createSessionMock).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- test that upsell route uses correct Stripe price IDs for pro and master upgrades
- test that invalid upsell offers return 400

## Testing
- `npx jest __tests__/checkout-route.test.ts __tests__/upsell-route.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68998b0a562083289c81192aeba58b25