### PR TITLE
Handle checkout fetch errors

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/app/products/page.tsx
+++ b/ARIA_Master_Deploy_Enterprise 333/app/products/page.tsx
@@ -6,13 +6,19 @@ export default function Products() {
   const [bumpChecked, setBumpChecked] = useState(true);
   const handleCheckout = async (priceId?: string, tier?: string) => {
     if (!priceId) return;
-    const res = await fetch('/api/checkout', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ priceId, bump: bumpChecked, tier })
-    });
-    const data = await res.json();
-    if (data.url) window.location.href = data.url;
+    try {
+      const res = await fetch('/api/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ priceId, bump: bumpChecked, tier })
+      });
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      if (data.url) window.location.href = data.url;
+    } catch (err) {
+      console.error('Checkout request failed', err);
+      alert('Unable to start checkout. Please try again later.');
+    }
   };
   return (
     <div className="max-w-6xl mx-auto px-4 py-16">


### PR DESCRIPTION
## Summary
- wrap checkout fetch in try/catch
- check response status before parsing
- alert user on checkout failure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: ReferenceError: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68998b0d3450832882c1c6a7fac68226