### PR TITLE
chore: rename Next.js config to CJS

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/next.config.cjs
+++ b/ARIA_Master_Deploy_Enterprise 333/next.config.cjs
@@ -1,0 +1,12 @@
+const path = require('path');
+
+module.exports = {
+  reactStrictMode: true,
+  images: {
+    formats: ['image/avif', 'image/webp'],
+  },
+  webpack: (config) => {
+    config.resolve.alias['@'] = path.resolve(__dirname);
+    return config;
+  },
+};

--- a/ARIA_Master_Deploy_Enterprise 333/next.config.js
+++ b/ARIA_Master_Deploy_Enterprise 333/next.config.js
@@ -1,1 +1,0 @@
-module.exports = { reactStrictMode: true, images: { formats: ['image/avif','image/webp'] } }


### PR DESCRIPTION
## Summary
- rename Next.js config to CommonJS format and define `@` root alias

## Testing
- `npm run build` *(fails: Module not found: Can't resolve '@/lib/products')*

------
https://chatgpt.com/codex/tasks/task_e_68999cd5e7308328aaa15640b03d29d5