### PR TITLE
chore: add test script and dev deps

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/package.json
+++ b/ARIA_Master_Deploy_Enterprise 333/package.json
@@ -7,12 +7,20 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "stripe:bootstrap": "node scripts/bootstrap_products_from_csv.mjs data/products.csv"
+    "stripe:bootstrap": "node scripts/bootstrap_products_from_csv.mjs data/products.csv",
+    "test": "jest"
   },
   "dependencies": {
     "next": "14.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "stripe": "^16.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest test script and testing-related dev dependencies to package.json

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68999cdd962c8328bd3b3956b9dae8be