### PR TITLE
fix: rename upsell map and add tests

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/__tests__/upsell-route.test.ts
+++ b/ARIA_Master_Deploy_Enterprise 333/__tests__/upsell-route.test.ts
@@ -1,0 +1,50 @@
+import Stripe from 'stripe';
+import type { NextRequest } from 'next/server';
+
+// Mock the Stripe SDK
+const createSessionMock = jest.fn().mockResolvedValue({ url: 'https://example.com/session' });
+
+jest.mock('stripe', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      checkout: { sessions: { create: createSessionMock } },
+    })),
+  };
+});
+
+describe('POST /api/upsell', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    createSessionMock.mockClear();
+    process.env.STRIPE_SECRET_KEY = 'sk_test';
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://example.com';
+    process.env.NEXT_PUBLIC_STRIPE_PRICE_UPGRADE_TO_PRO = 'price_pro';
+    process.env.NEXT_PUBLIC_STRIPE_PRICE_UPGRADE_TO_MASTER = 'price_master';
+  });
+
+  it('creates session for known offer', async () => {
+    const { POST } = await import('@/app/api/upsell/route');
+    const body = { offer: 'pro-upgrade' };
+    const req = { json: async () => body } as unknown as NextRequest;
+
+    await POST(req);
+
+    expect(createSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: 'price_pro', quantity: 1 }],
+      }),
+    );
+  });
+
+  it('returns 400 for unknown offer', async () => {
+    const { POST } = await import('@/app/api/upsell/route');
+    const body = { offer: 'unknown' };
+    const req = { json: async () => body } as unknown as NextRequest;
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+});
+

--- a/ARIA_Master_Deploy_Enterprise 333/app/api/upsell/route.ts
+++ b/ARIA_Master_Deploy_Enterprise 333/app/api/upsell/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
 
-const UPSSELL_MAP: Record<string, string> = {
+const UPSELL_MAP: Record<string, string> = {
   'pro-upgrade': process.env.NEXT_PUBLIC_STRIPE_PRICE_UPGRADE_TO_PRO || '',
   'master-upgrade': process.env.NEXT_PUBLIC_STRIPE_PRICE_UPGRADE_TO_MASTER || ''
 };
 
 export async function POST(req: NextRequest) {
   const { offer } = await req.json();
-  const priceId = UPSSELL_MAP[offer];
+  const priceId = UPSELL_MAP[offer];
   if (!priceId) return NextResponse.json({ error: 'Offer not available' }, { status: 400 });
 
   if (!process.env.STRIPE_SECRET_KEY) return NextResponse.json({ error: 'Missing STRIPE_SECRET_KEY' }, { status: 500 });


### PR DESCRIPTION
## Summary
- rename UPSSELL_MAP to UPSELL_MAP and update references
- add tests covering upsell route behavior

## Testing
- `npx jest __tests__/upsell-route.test.ts __tests__/checkout-route.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68999d4a6f9c83289d8993d37c5a33f7