### PR TITLE
chore: add type tooling

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/next-env.d.ts
+++ b/ARIA_Master_Deploy_Enterprise 333/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/ARIA_Master_Deploy_Enterprise 333/package.json
+++ b/ARIA_Master_Deploy_Enterprise 333/package.json
@@ -14,5 +14,13 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "stripe": "^16.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.0.0",
+    "autoprefixer": "^10.0.0",
+    "postcss": "^8.0.0",
+    "tailwindcss": "^3.0.0",
+    "typescript": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add TypeScript and related tooling as dev dependencies
- include default Next.js type declaration file

## Testing
- `npx tsc --noEmit` (fails: Cannot find name 'jest')
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68999d35650c8328bf00ea787e7d2710