### PR TITLE
fix stripe bootstrap script

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/scripts/bootstrap_products_from_csv.mjs
+++ b/ARIA_Master_Deploy_Enterprise 333/scripts/bootstrap_products_from_csv.mjs
@@ -10,18 +10,20 @@ if (!process.env.STRIPE_SECRET_KEY) {
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
 
 const csvPath = path.join(process.cwd(), 'data', 'products.csv');
-const rows = fs.readFileSync(csvPath, 'utf-8').trim().split(/?
-/);
-const headers = rows.shift().split(',').map(h=>h.trim());
-
-function parseRow(line) {
-  const cells = line.split(',').map(c=>c.trim());
-  const obj = {}; headers.forEach((h,i)=>obj[h]=cells[i]||'');
-  return obj;
-}
-
-const items = rows.map(parseRow);
-
+const rows = fs.readFileSync(csvPath, 'utf-8').trim().split(/\r?\n/);
+const headers = rows.shift().split(',').map(h => h.trim());
+  const cells = line.split(',').map(c => c.trim());
+  const obj = {};
+  headers.forEach((h, i) => {
+    obj[h] = cells[i] || '';
+  });
+    name: item.name,
+    description: item.description,
+  });
+NEXT_PUBLIC_STRIPE_PRICE_STARTER=${results.find(x=>x.sku==='starter-kit')?.priceId || ''}
+NEXT_PUBLIC_STRIPE_PRICE_PRO=${results.find(x=>x.sku==='professional-suite')?.priceId || ''}
+NEXT_PUBLIC_STRIPE_PRICE_MASTER=${results.find(x=>x.sku==='master-collection')?.priceId || ''}
+console.log('Wrote env.output.txt with the price IDs. Paste them into .env.local and Vercel.');
 const results = [];
 for (const item of items) {
   const product = await stripe.products.create({


### PR DESCRIPTION
## Summary
- fix CSV rows parsing to trim and split correctly
- create products and prices without stray env vars
- output Stripe price IDs for each product

## Testing
- `npm run stripe:bootstrap` *(fails: StripeConnectionError ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68999d48d3dc83288aaea5ab115dbdc5