### PR TITLE
chore: add jest testing setup

### DIFF
--- a/ARIA_Master_Deploy_Enterprise 333/jest.config.cjs
+++ b/ARIA_Master_Deploy_Enterprise 333/jest.config.cjs
@@ -1,0 +1,13 @@
+const { createDefaultPreset } = require('ts-jest/presets');
+const tsJestTransform = createDefaultPreset().transform;
+
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    ...tsJestTransform,
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};

--- a/ARIA_Master_Deploy_Enterprise 333/jest.setup.ts
+++ b/ARIA_Master_Deploy_Enterprise 333/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/ARIA_Master_Deploy_Enterprise 333/package.json
+++ b/ARIA_Master_Deploy_Enterprise 333/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "jest",
     "stripe:bootstrap": "node scripts/bootstrap_products_from_csv.mjs data/products.csv"
   },
   "dependencies": {
@@ -14,5 +15,12 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "stripe": "^16.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.1",
+    "@testing-library/react": "^14.2.1",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.1"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest configuration with ts-jest and path mapping
- include test script and testing dependencies

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)
- `npm test` (fails: jest: not found)

------
https://chatgpt.com/codex/tasks/task_e_68999d47969c8328bb8a3ecc16255335