### PR TITLE
Set up Jest testing and ignore local dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/ARIA_Master_Deploy_Enterprise 333/jest.config.cjs
+++ b/ARIA_Master_Deploy_Enterprise 333/jest.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+};

--- a/ARIA_Master_Deploy_Enterprise 333/package.json
+++ b/ARIA_Master_Deploy_Enterprise 333/package.json
@@ -7,12 +7,18 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "stripe:bootstrap": "node scripts/bootstrap_products_from_csv.mjs data/products.csv"
+    "stripe:bootstrap": "node scripts/bootstrap_products_from_csv.mjs data/products.csv",
+    "test": "jest"
   },
   "dependencies": {
     "next": "14.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "stripe": "^16.0.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.5"
   }
 }


### PR DESCRIPTION
## Summary
- add Node `.gitignore` patterns for node_modules and package-lock.json
- configure Jest with ts-jest and alias mapping
- add test script and Jest dev dependencies to package.json

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899a2349fd08328bca50055fc2b5cb9